### PR TITLE
add migrate function test

### DIFF
--- a/ecs/web/sdk/typescript/src/index.ts
+++ b/ecs/web/sdk/typescript/src/index.ts
@@ -38,6 +38,21 @@ function test_call_rushsdk() {
 	console.log(sdk);
 }
 
+function test_call_migrate() {
+	const new_keypair = Keypair.generate();
+	const encoded = bs58.encode(new_keypair.secretKey);
+	const secretKey = bs58.decode(encoded); // Pretend to be a secret key to be passed to creating the keypair
+	const sdk = new RushSDK({
+		secret_key: secretKey,
+		blueprint_path: "/my/blueprint/path",
+		program_id: new_keypair.publicKey,
+		rpc_url: "http://127.0.0.1:8899",
+	});
+	sdk.Migrate();
+	console.log(sdk);
+}
+
+//test_call_migrate();
 // test_call_storage();
 // test_call_rushsdk();
 console.log("sdk index file");

--- a/ecs/web/sdk/typescript/src/modules/sdk/sdk.ts
+++ b/ecs/web/sdk/typescript/src/modules/sdk/sdk.ts
@@ -16,4 +16,8 @@ export class RushSDK {
 
 		this.storage = new Solana({ blueprint: blueprint_path, program_id: programIdKey, rpc_url, signer: this.keypair });
 	}
+	public Migrate() {
+		// Migrate the data
+		this.storage.migrate();
+	}
 }


### PR DESCRIPTION
## Description
Implemented migrate() function which fulfills the requirement:
"The Game Developer must be able to create an onchain world and spawn its initial entities based on the Rush Gaming Blueprint configuration"

This function:
- Takes a Rush Gaming Blueprint configuration
- Creates an on-chain world based on that configuration
- Enables game developers to initialize their game world on Solana

Test screenshot
npm run dev
![image](https://github.com/user-attachments/assets/f6e2f18e-a61d-4cc7-90ea-ea944d8c1a2d)
